### PR TITLE
Refactoring media query #11

### DIFF
--- a/src/commons/styles/mediaQuery.ts
+++ b/src/commons/styles/mediaQuery.ts
@@ -1,0 +1,14 @@
+import { SerializedStyles, css } from "@emotion/react";
+import { breakPoints } from "./palette";
+
+export const setTabletStyle = (style: SerializedStyles) => css`
+  @media screen and (max-width: ${breakPoints.tablet}px) {
+    ${style}
+  }
+`;
+
+export const setMobileStyle = (style: SerializedStyles) => css`
+  @media screen and (max-width: ${breakPoints.mobile}px) {
+    ${style}
+  }
+`;

--- a/src/components/commons/layout/MBSearchButton.tsx
+++ b/src/components/commons/layout/MBSearchButton.tsx
@@ -1,4 +1,6 @@
+import { css } from "@emotion/react";
 import styled from "@emotion/styled";
+import { setMobileStyle } from "commons/styles/mediaQuery";
 import { breakPoints, colors } from "commons/styles/palette";
 
 export default function MBSearchButton() {
@@ -14,7 +16,7 @@ export default function MBSearchButton() {
 const WriteButton = styled.div`
   display: none;
 
-  @media screen and (max-width: ${breakPoints.mobile}px) {
+  ${setMobileStyle(css`
     display: flex;
     justify-content: center;
     align-items: center;
@@ -28,7 +30,7 @@ const WriteButton = styled.div`
     box-shadow: 4px 4px 12px rgba(54, 53, 81 0.25);
     border-radius: 16px;
     cursor: pointer;
-  }
+  `)}
 `;
 
 const WriteIcon = styled.div`

--- a/src/components/commons/layout/header/Header.styles.ts
+++ b/src/components/commons/layout/header/Header.styles.ts
@@ -1,5 +1,7 @@
+import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import { breakPoints, colors } from "commons/styles/palette";
+import { setMobileStyle, setTabletStyle } from "commons/styles/mediaQuery";
+import { colors } from "commons/styles/palette";
 
 export const Wrapper = styled.div`
   display: flex;
@@ -11,13 +13,13 @@ export const Wrapper = styled.div`
   padding: 0 13.75vw;
   background-color: #f7f9fb;
 
-  @media screen and (max-width: ${breakPoints.tablet}px) {
+  ${setTabletStyle(css`
     padding: 0 1.668vw;
-  }
+  `)}
 
-  @media screen and (max-width: ${breakPoints.mobile}px) {
+  ${setMobileStyle(css`
     padding: 0 2.086vw;
-  }
+  `)}
 `;
 
 export const LogoContainer = styled.div`
@@ -39,9 +41,9 @@ export const PCTBRightContainer = styled.div`
   width: 100px;
   height: 100%;
 
-  @media screen and (max-width: ${breakPoints.mobile}px) {
+  ${setMobileStyle(css`
     display: none;
-  }
+  `)}
 `;
 
 export const AlertSearchIcon = styled.div`
@@ -82,16 +84,14 @@ export const ProfileButtonIcon = styled.img`
 export const MBRightContainer = styled.div`
   display: none;
 
-  @media screen and (max-width: ${breakPoints.mobile}px) {
-    visibility: visible;
-    opacity: 1;
+  ${setMobileStyle(css`
     display: flex;
     justify-content: space-between;
     align-items: center;
 
     width: 51px;
     height: 100%;
-  }
+  `)}
 `;
 
 export const HamburgerIcon = styled.div`

--- a/src/components/commons/layout/searchBar/SearchBar.styles.ts
+++ b/src/components/commons/layout/searchBar/SearchBar.styles.ts
@@ -1,5 +1,7 @@
+import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import { breakPoints, colors, fontSize } from "commons/styles/palette";
+import { setMobileStyle, setTabletStyle } from "commons/styles/mediaQuery";
+import { colors, fontSize } from "commons/styles/palette";
 
 export const Wrapper = styled.div`
   display: flex;
@@ -11,14 +13,14 @@ export const Wrapper = styled.div`
   padding: 0 12.5vw;
   border-bottom: 1px solid ${colors.black[800]};
 
-  @media screen and (max-width: ${breakPoints.tablet}px) {
+  ${setTabletStyle(css`
     padding: 0 1.668vw;
     height: 64px;
-  }
+  `)}
 
-  @media screen and (max-width: ${breakPoints.mobile}px) {
+  ${setMobileStyle(css`
     display: none;
-  }
+  `)}
 `;
 
 export const SearchWrapper = styled.div`


### PR DESCRIPTION
## Why need this change? 🧐
- style 파일마다 media query 구문을 찾아 복사 붙여넣기하는 수고로움 + 실수를 덜기 위해 emotion에서 지원하는 기능을 활용하여 공통 함수를 만듦

<br />

## Changes made ✍🏻
- 각각 흩어져있는 media query 구문을 삭제하고, 해당 함수들을 import 함으로써 해당 breakpoint 부분을 명료하게 볼 수 있고, 구문을 복사 붙여넣기 할 필요성도 없어졌습니다.
- breakpoint가 추가될 경우 mediaQuery 파일에 추가적으로 추가만 하면 됩니다.

<br />

## Screenshot (optional) 📸


<br />
